### PR TITLE
feat(cc_so): opinionated sol names

### DIFF
--- a/cc_hdrs_map/actions/link_to_so.bzl
+++ b/cc_hdrs_map/actions/link_to_so.bzl
@@ -66,7 +66,9 @@ def _link_to_so_impl(
     cc_toolchain = find_cc_toolchain(sctx)
 
     sol_name = shared_lib_name if shared_lib_name else sctx.label.name
-    sol_name = sol_name.removeprefix("lib")
+
+    # Opinionated part: prevent any liblibName or libName.so.so or libName.so.test.so
+    sol_name = sol_name.removeprefix("lib").replace(".so", "")
 
     # TODO: Linker inputs from CcInfo ?
     # TODO: dedup with cc_bin


### PR DESCRIPTION
This changeset ensures that the name of the created sol files should always start with singular 'lib' and end with singular '.so' suffix.