### PR TITLE
test(examples): extended the simple targets

### DIFF
--- a/examples/simple/deck/BUILD.bazel
+++ b/examples/simple/deck/BUILD.bazel
@@ -3,16 +3,16 @@
 load("@rules_cc_hdrs_map//cc_hdrs_map:defs.bzl", "cc_so")
 
 cc_so(
-    name = "libRandom",
-    srcs = ["random.cpp"],
-    hdrs = ["random.hpp"],
+    name = "libDeck",
+    srcs = ["deck.cpp"],
+    hdrs = ["deck.hpp"],
     copts = [
         "-Wall",
         "-Wextra",
         "-Werror",
     ],
     hdrs_map = {
-        "**/random.hpp": ["modnar/{filename}"],
+        "**/deck.hpp": ["kced/{filename}"],
     },
     linkopts = [
         "-Wall",
@@ -20,7 +20,6 @@ cc_so(
         "-Werror",
         "-Wl,--unresolved-symbols=report-all",
     ],
-    # SOL name, even with such wierd name request, should be: libRandom.so
-    shared_lib_name = "lib.soRandom.so",
     visibility = ["//visibility:public"],
+    deps = ["//simple/random:libRandom"],
 )

--- a/examples/simple/deck/deck.cpp
+++ b/examples/simple/deck/deck.cpp
@@ -1,0 +1,40 @@
+#include "kced/deck.hpp"
+#include "modnar/random.hpp"
+
+#include <algorithm>
+#include <random>
+
+std::vector<std::string> Deck::new_deck() {
+  std::vector<std::string> deck = {
+    "🂡 ","🂱 ","🃁 ","🃑 ",
+    "🂢 ","🂲 ","🃂 ","🃒 ",
+    "🂣 ","🂳 ","🃃 ","🃓 ",
+    "🂤 ","🂴 ","🃄 ","🃔 ",
+    "🂥 ","🂵 ","🃅 ","🃕 ",
+    "🂦 ","🂶 ","🃆 ","🃖 ",
+    "🂧 ","🂷 ","🃇 ","🃗 ",
+    "🂨 ","🂸 ","🃈 ","🃘 ",
+    "🂩 ","🂹 ","🃉 ","🃙 ",
+    "🂪 ","🂺 ","🃊 ","🃚 ",
+    "🂫 ","🂻 ","🃋 ","🃛 ",
+    "🂬 ","🂼 ","🃌 ","🃜 ",
+    "🂭 ","🂽 ","🃍 ","🃝 ",
+    "🂮 ","🂾 ","🃎 ","🃞 ",
+  };
+  return deck;
+}
+
+void Deck::shuffle() {
+  std::random_device r;
+  std::default_random_engine rng(r());
+  std::shuffle(std::begin(this->cards), std::end(this->cards), rng);
+}
+
+std::string &Deck::getRandomCard() {
+   auto randomIndex = randomNumber();
+   return this->cards[randomIndex];
+}
+
+Deck::Deck() {
+   this->cards = Deck::new_deck();
+}

--- a/examples/simple/deck/deck.hpp
+++ b/examples/simple/deck/deck.hpp
@@ -1,0 +1,16 @@
+#ifndef DECK_HPP
+#define DECK_HPP
+
+#include <string>
+#include <vector>
+
+class Deck {
+  std::vector<std::string> cards;
+  public:
+    Deck();
+    void shuffle();
+    std::string &getRandomCard();
+  private:
+    static std::vector<std::string> new_deck();
+};
+#endif

--- a/examples/simple/main/main.cpp
+++ b/examples/simple/main/main.cpp
@@ -1,6 +1,6 @@
 #include "jolly/messenger.hpp"
 
 int main() {
-  messengerSays();
+  printRandomDeckCard();
   return 0;
 }

--- a/examples/simple/messenger/BUILD.bazel
+++ b/examples/simple/messenger/BUILD.bazel
@@ -27,6 +27,6 @@ cc_so(
     visibility = ["//visibility:public"],
     deps = [
         ":messenger-headers",
-        "//simple/random:libRandom",
+        "//simple/deck:libDeck",
     ],
 )

--- a/examples/simple/messenger/messenger.cpp
+++ b/examples/simple/messenger/messenger.cpp
@@ -1,7 +1,8 @@
 #include "messenger/messenger.hpp"
-#include "modnar/random.hpp"
+#include "kced/deck.hpp"
 
-void messengerSays() {
-   std::cout << "Messenger says: " << MESSAGE << std::endl;
-   printRandomNumber();
+void printRandomDeckCard() {
+   auto deck = new Deck();
+   deck->shuffle();
+   std::cout << "Random card from a deck: " << deck->getRandomCard() << std::endl;
 }

--- a/examples/simple/messenger/messenger.hpp
+++ b/examples/simple/messenger/messenger.hpp
@@ -4,8 +4,6 @@
 #include <iostream>
 #include <string>
 
-const std::string MESSAGE = "🃜 🃚 🃖 🃁 🂭 🂺!";
-
-void messengerSays();
+void printRandomDeckCard();
 
 #endif

--- a/examples/simple/random/random.cpp
+++ b/examples/simple/random/random.cpp
@@ -1,5 +1,8 @@
 #include "modnar/random.hpp"
 
-void printRandomNumber() {
-   std::cout << "Random number: " << rand() % 100 << std::endl;
+#include <cstdlib>
+#include <ctime>
+
+unsigned short int randomNumber() {
+   return (rand() % 52);
 }

--- a/examples/simple/random/random.hpp
+++ b/examples/simple/random/random.hpp
@@ -1,9 +1,6 @@
 #ifndef RANDOM_HPP
 #define RANDOM_HPP
 
-#include <iostream>
-#include <cstdlib>
-
-void printRandomNumber();
+unsigned short int randomNumber();
 
 #endif


### PR DESCRIPTION
This change extends the example targets located
under 'examples/simple' subdirectory, aiming
to showcase how chains of SOL dependencies
are supposed to behave.