### PR TITLE
feat(compile): treat hdrs from srcs as implementation hdrs

### DIFF
--- a/cc_hdrs_map/actions/cc_helper.bzl
+++ b/cc_hdrs_map/actions/cc_helper.bzl
@@ -2,6 +2,61 @@
 
 load("@rules_cc//cc/common:cc_helper.bzl", rules_cc_helper = "cc_helper")
 
+# TODO: Perhaps a PR to `rules_cc` to expose extensions method?
+# https://github.com/bazelbuild/bazel/blob/6d811c80720584eac50372b866d063aebd37e2e5/src/main/starlark/builtins_bzl/common/cc/cc_helper_internal.bzl#L94
+CC_HEADER_EXTENSIONS = [
+    ".h",
+    ".hh",
+    ".hpp",
+    ".ipp",
+    ".hxx",
+    ".h++",
+    ".inc",
+    ".inl",
+    ".tlh",
+    ".tli",
+    ".H",
+    ".tcc",
+]
+CC_SOURCE_EXTENSIONS = [
+    "c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".c++",
+    ".C",
+    ".cu",
+    ".cl",
+]
+
+def _extract_headers(files):
+    hdrs = []
+    if not files:
+        return hdrs
+
+    for file in files:
+        extension = "." + file.extension
+        if not extension in CC_HEADER_EXTENSIONS:
+            continue
+
+        hdrs.append(file)
+
+    return hdrs
+
+def _extract_sources(files):
+    srcs = []
+    if not files:
+        return srcs
+
+    for file in files:
+        extension = "." + file.extension
+        if not extension in CC_SOURCE_EXTENSIONS:
+            continue
+
+        srcs.append(file)
+
+    return srcs
+
 # Author soap box:
 # I do not understand the obsession with making everything private,
 # especially that Starlark is based on Python.
@@ -264,6 +319,8 @@ def _get_linking_opts(sctx, opts, additional_make_variable_substitutions = {}, a
     return results
 
 cc_helper = struct(
+    extract_headers = _extract_headers,
+    extract_sources = _extract_sources,
     get_compilation_defines = _get_compilation_defines,
     get_compilation_opts = _get_compilation_opts,
     get_linking_opts = _get_linking_opts,

--- a/cc_hdrs_map/actions/compile.bzl
+++ b/cc_hdrs_map/actions/compile.bzl
@@ -164,7 +164,7 @@ def _compile_impl(
         sctx,
         input_hdrs_map = hdrs_map,
         input_hdrs = hdrs,
-        input_implementation_hdrs = implementation_hdrs,
+        input_implementation_hdrs = implementation_hdrs + cc_helper.extract_headers(srcs),
         input_deps = deps,
         input_includes = includes,
     )
@@ -203,7 +203,7 @@ def _compile_impl(
         #
         # Source files
         # TODO: Guard against duplicates
-        srcs = srcs,
+        srcs = cc_helper.extract_sources(srcs),
         # TODO: Guard against duplicates, read headers from srcs
         public_hdrs = hdrs,
         private_hdrs = implementation_hdrs,

--- a/cc_hdrs_map/private/attrs.bzl
+++ b/cc_hdrs_map/private/attrs.bzl
@@ -1,5 +1,7 @@
 """ Contains common configuration-related entities used by cc_hdrs_map rules. """
 
+load("@rules_cc_hdrs_map//cc_hdrs_map/actions:cc_helper.bzl", "CC_HEADER_EXTENSIONS", "CC_SOURCE_EXTENSIONS")
+
 _COMMON_RULES_ATTRS = {
     "data": struct(
         attr = attr.label_list(
@@ -30,14 +32,8 @@ _COMMON_RULES_ATTRS = {
     "srcs": struct(
         attr = attr.label_list(
             mandatory = True,
-            allow_files = [
-                ".c",
-                ".cc",
-                ".cpp",
-                ".cxx",
-                ".c++",
-                ".C",
-            ],
+            # Perhaps in future we can disallow headers here
+            allow_files = CC_SOURCE_EXTENSIONS + CC_HEADER_EXTENSIONS,
             doc = "The list of source files.",
         ),
         as_action_param = struct(
@@ -49,15 +45,7 @@ _COMMON_RULES_ATTRS = {
     ),
     "hdrs": struct(
         attr = attr.label_list(
-            allow_files = [
-                ".h",
-                ".hh",
-                ".hpp",
-                ".hxx",
-                ".inc",
-                ".inl",
-                ".H",
-            ],
+            allow_files = CC_HEADER_EXTENSIONS,
             doc = """ 
         List of headers that may be included by dependent rules transitively.
         Notice: the cutoff happens during compilation.
@@ -73,15 +61,7 @@ _COMMON_RULES_ATTRS = {
     ),
     "implementation_hdrs": struct(
         attr = attr.label_list(
-            allow_files = [
-                ".h",
-                ".hh",
-                ".hpp",
-                ".hxx",
-                ".inc",
-                ".inl",
-                ".H",
-            ],
+            allow_files = CC_HEADER_EXTENSIONS,
             doc = """
         List of headers that CANNOT be included by dependent rules.
         Notice: the cutoff happens during compilation.

--- a/cc_hdrs_map/private/common.bzl
+++ b/cc_hdrs_map/private/common.bzl
@@ -1,7 +1,7 @@
 """ Contains common logic shared between rules implementation(s). """
 
 def prepare_default_runfiles(attr_data, ctx_runfiles_fun):
-    """ aaa """
+    """ The default list of runfiles, gathered from the data attribute. """
     runfiles = []
     for data_dep in attr_data:
         if data_dep[DefaultInfo].data_runfiles.files:

--- a/examples/simple/main/BUILD.bazel
+++ b/examples/simple/main/BUILD.bazel
@@ -4,10 +4,25 @@ load("@rules_cc_hdrs_map//cc_hdrs_map:defs.bzl", "cc_bin")
 
 cc_bin(
     name = "main",
-    srcs = ["main.cpp"],
+    srcs = [
+        "main.cpp",
+        "main.hpp",
+    ],
+    copts = [
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+    ],
     hdrs_map = {
         "**/messenger.hpp": ["jolly/{filename}"],
+        "**/main.hpp": ["lucky/lucky.hpp"],
     },
+    linkopts = [
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wl,--unresolved-symbols=report-all",
+    ],
     deps = [
         "//simple/messenger:libMessenger",
     ],

--- a/examples/simple/main/main.cpp
+++ b/examples/simple/main/main.cpp
@@ -1,6 +1,10 @@
+#include <iostream>
+
 #include "jolly/messenger.hpp"
+#include "lucky/lucky.hpp"
 
 int main() {
   printRandomDeckCard();
+  std::cout << LUCKY_NUMBER << std::endl;
   return 0;
 }

--- a/examples/simple/main/main.hpp
+++ b/examples/simple/main/main.hpp
@@ -1,0 +1,6 @@
+#ifndef MAIN_HPP
+#define MAIN_HPP
+
+static const int LUCKY_NUMBER = 42;
+
+#endif


### PR DESCRIPTION
This changeset allows users to add header files
inside the 'srcs' attribute of compilable rules and will treat them as implementation headers
(they will not be propagated forward).