### PR TITLE
fix(cc_archive|cc_so): too eager name cleaning

### DIFF
--- a/cc_hdrs_map/actions/link_to_archive.bzl
+++ b/cc_hdrs_map/actions/link_to_archive.bzl
@@ -38,7 +38,7 @@ def _link_to_archive_impl(
     archive_lib_name = archive_lib_name if archive_lib_name else sctx.label.name
 
     # Opinionated part: prevent any liblibName or libName.a.a or libName.a.test.a
-    archive_lib_name = archive_lib_name.removeprefix("lib").replace(".a", "")
+    archive_lib_name = archive_lib_name.removeprefix("lib").replace(".a.", ".").removesuffix(".a")
 
     features_configuration = configure_features_func(
         cc_toolchain,

--- a/cc_hdrs_map/actions/link_to_so.bzl
+++ b/cc_hdrs_map/actions/link_to_so.bzl
@@ -64,7 +64,7 @@ def _link_to_so_impl(
     sol_name = shared_lib_name if shared_lib_name else sctx.label.name
 
     # Opinionated part: prevent any liblibName or libName.so.so or libName.so.test.so
-    sol_name = sol_name.removeprefix("lib").replace(".so", "")
+    sol_name = sol_name.removeprefix("lib").replace(".so.", ".").removesuffix(".so")
 
     # TODO: Linker inputs from CcInfo ?
     # TODO: dedup with cc_bin


### PR DESCRIPTION
This changeset resolves the issue of too aggresive logic responsible for prevention of naming the
targets with name containing '.a. ' or '.so.'.

After this fix only the blacklisted part
should be removed from the output name.