### PR TITLE
feat(cc_archive): switch to cc_common implementation

### DIFF
--- a/cc_hdrs_map/private/attrs.bzl
+++ b/cc_hdrs_map/private/attrs.bzl
@@ -179,8 +179,7 @@ _CC_COMPILABLE_ATTRS = {
         ),
         as_action_param = struct(
             compile = lambda ctx_attr: None,
-            # TODO(agondek): additional_inputs for link_to_archive
-            link_to_archive = lambda ctx_attr: None,
+            link_to_archive = lambda ctx_attr: ("additional_inputs", getattr(ctx_attr, "additional_linker_inputs", [])),
             link_to_bin = lambda ctx_attr: ("additional_inputs", getattr(ctx_attr, "additional_linker_inputs", [])),
             link_to_so = lambda ctx_attr: ("additional_inputs", getattr(ctx_attr, "additional_linker_inputs", [])),
         ),

--- a/cc_hdrs_map/private/cc_archive.bzl
+++ b/cc_hdrs_map/private/cc_archive.bzl
@@ -15,12 +15,21 @@ def _cc_archive_impl(ctx):
         **actions.link_to_archive_kwargs(ctx, CC_ARCHIVE_ATTRS)
     )
 
+    archive = getattr(
+        linking_results.cc_linking_outputs.library_to_link,
+        "pic_static_library",
+        None,
+    )
+    archive = archive if archive else getattr(
+        linking_results.cc_linking_outputs.library_to_link,
+        "static_library",
+        None,
+    )
+
     return [
         DefaultInfo(
-            files = depset(
-                linking_results.cc_linking_outputs.static_libraries,
-            ),
-            runfiles = prepare_default_runfiles(ctx.runfiles, ctx.attr.data, ctx.attr.deps, files = linking_results.cc_linking_outputs.static_libraries),
+            files = depset([archive]),
+            runfiles = prepare_default_runfiles(ctx.runfiles, ctx.attr.data, ctx.attr.deps, files = [archive]),
         ),
         CcInfo(
             compilation_context = compilation_ctx,


### PR DESCRIPTION
This changeset switches the logic responsible for
linking archives from a fully custom one (that
was written to showcase such possibility) to
cc_common, that is better suites to handle
more comples scenarios.