### PR TITLE
feat(nix-shell): starpls capability to use bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
 .bazel
 .bazel-user-root
+.bazelisk-bin
 # Weird that it does not break on the WORKSPACE on its own
 examples

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bazel
 .bazel-*
+.bazelisk-bin
 result

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,12 @@
       runScript = nixpkgs.writeScript "rules_cc_hdrs_map-shell-init.sh" ''
         shellHooksPath=$(mktemp --suffix=rules_cc_hdrs_map-shell.bazelrc)
         cat <<EOF > $shellHooksPath
-          alias bazel=${nixpkgs.bazelisk}/bin/bazelisk
+          # Just using an 'alias=...'
+          # will not work for binaries like starpls, that execute items
+          # directly from path.
+          mkdir -p .bazelisk-bin
+          ln -f -s ${nixpkgs.bazelisk}/bin/bazelisk .bazelisk-bin/bazel
+          export PATH="$(realpath .bazelisk-bin)/:$PATH"
         EOF
 
         exec bash --rcfile $shellHooksPath
@@ -54,7 +59,9 @@
     name = "rules_cc_hdrs_map-non_fhs_shell";
     packages = devShellPackages nixpkgs;
     shellHook = ''
-      alias bazel=${nixpkgs.bazelisk}/bin/bazelisk
+      mkdir -p .bazelisk-bin
+      ln -f -s ${nixpkgs.bazelisk}/bin/bazelisk .bazelisk-bin/bazel
+      export PATH="$(realpath .bazelisk-bin)/:$PATH"
     '';
   };
 in {


### PR DESCRIPTION
This change adds the bazelisk (aliased as bazel)
to the development shells $PATH, thus making it
possible for starpls to execute it and pull
in required information about Bazel external
repositories in the WORKSPACE.