### PR TITLE
feat(hdrs_map_info): gather HdrsMapInfo transitively

### DIFF
--- a/cc_hdrs_map/actions/cc_helper.bzl
+++ b/cc_hdrs_map/actions/cc_helper.bzl
@@ -320,7 +320,6 @@ def _get_linking_opts(sctx, extra_ctx_members, opts, additional_make_variable_su
 
     return results
 
-# TODO(agondek): Important! This should recurse into dependencies in search for HdrsMapInfo deps..
 def _prepare_for_compilation(
         sctx,
         input_hdrs_map,
@@ -351,10 +350,15 @@ def _prepare_for_compilation(
     # Pattern of '{filename}' resolves to any direct header file of the rule instance
     hdrs_map.pin_down_non_globs(hdrs = hdrs + implementation_hdrs)
 
-    # Merge with deps
+    # Traverse dependencies and extract:
+    # HdrsMapInfo (trainsitive), CcInfo (first order) and CcSharedLibraryInfo (first order)
     deps_pub_hdrs, deps_prv_hdrs, hdrs_map, deps_deps = quotient_map_hdrs_map_infos(
         targets = deps,
+        hdrs = None,
+        implementation_hdrs = None,
         hdrs_map = hdrs_map,
+        hdrs_map_deps = None,
+        traverse_deps = True,
     )
     hdrs = depset(direct = hdrs, transitive = [deps_pub_hdrs])
     implementation_hdrs = depset(direct = implementation_hdrs, transitive = [deps_prv_hdrs])

--- a/cc_hdrs_map/private/cc_hdrs.bzl
+++ b/cc_hdrs_map/private/cc_hdrs.bzl
@@ -20,7 +20,12 @@ def _cc_hdrs_impl(ctx):
 
     deps_pub_hdrs, deps_prv_hdrs, hdrs_map, deps_deps = quotient_map_hdrs_map_infos(
         targets = deps,
+        hdrs = None,
+        implementation_hdrs = None,
         hdrs_map = hdrs_map,
+        hdrs_map_deps = None,
+        # DO NOT pay the transitive traversal cost upfront
+        traverse_deps = False,
     )
 
     hdrs = depset(direct = hdrs, transitive = [deps_pub_hdrs])

--- a/docs/README.md
+++ b/docs/README.md
@@ -562,7 +562,7 @@ from said targets and the output will contain groups of that values.
 load("@rules_cc_hdrs_map//cc_hdrs_map:defs.bzl", "providers_helper")
 
 providers_helper.quotient_map_hdrs_map_infos(<a href="#providers_helper.quotient_map_hdrs_map_infos-targets">targets</a>, <a href="#providers_helper.quotient_map_hdrs_map_infos-hdrs">hdrs</a>, <a href="#providers_helper.quotient_map_hdrs_map_infos-implementation_hdrs">implementation_hdrs</a>, <a href="#providers_helper.quotient_map_hdrs_map_infos-hdrs_map">hdrs_map</a>,
-                                             <a href="#providers_helper.quotient_map_hdrs_map_infos-hdrs_map_deps">hdrs_map_deps</a>)
+                                             <a href="#providers_helper.quotient_map_hdrs_map_infos-hdrs_map_deps">hdrs_map_deps</a>, <a href="#providers_helper.quotient_map_hdrs_map_infos-traverse_deps">traverse_deps</a>)
 </pre>
 
 Take all HdrsMapInfo key-values and group them by keys.
@@ -576,7 +576,8 @@ Take all HdrsMapInfo key-values and group them by keys.
 | <a id="providers_helper.quotient_map_hdrs_map_infos-hdrs"></a>hdrs |  additional header files to include,   |  `None` |
 | <a id="providers_helper.quotient_map_hdrs_map_infos-implementation_hdrs"></a>implementation_hdrs |  additional implementation headers to include,   |  `None` |
 | <a id="providers_helper.quotient_map_hdrs_map_infos-hdrs_map"></a>hdrs_map |  initial hdrs_map to use as a foundation for merge,   |  `None` |
-| <a id="providers_helper.quotient_map_hdrs_map_infos-hdrs_map_deps"></a>hdrs_map_deps |  additional dependencies to include,   |  `None` |
+| <a id="providers_helper.quotient_map_hdrs_map_infos-hdrs_map_deps"></a>hdrs_map_deps |  additional dependencies to include   |  `None` |
+| <a id="providers_helper.quotient_map_hdrs_map_infos-traverse_deps"></a>traverse_deps |  wheather to gather HdrsMapInfos transitvely   |  `True` |
 
 **RETURNS**
 


### PR DESCRIPTION
This changeset aims to resolves issues with compilation of targets that have chains of HdrsMapInfo depending on each other.