### PR TITLE
feat(cc_sources): add extra extensions allowed

### DIFF
--- a/cc_hdrs_map/actions/cc_helper.bzl
+++ b/cc_hdrs_map/actions/cc_helper.bzl
@@ -29,6 +29,14 @@ CC_SOURCE_EXTENSIONS = [
     ".C",
     ".cu",
     ".cl",
+    # Non-standard additions:
+    # assembly
+    ".s",
+    ".S",
+    ".asm",
+    # pre-processed files
+    ".i",
+    ".ii",
 ]
 
 # Author soap box:


### PR DESCRIPTION
This changeset allows files related to assembly
language (.s, .S) and pre-preprocessed files
(.i, .ii) to be passed as a source to the
compiled rules.