### PR TITLE
fix(make-variables_expansion): will no longer trigger Bazel error

### DIFF
--- a/cc_hdrs_map/actions/cc_helper.bzl
+++ b/cc_hdrs_map/actions/cc_helper.bzl
@@ -50,16 +50,16 @@ CC_SOURCE_EXTENSIONS = [
 # Source: https://github.com/bazelbuild/rules_cc/blob/3dce172deec2a4563c28eae02a8bb18555abafb2/cc/common/cc_helper.bzl#L140
 # Source: https://github.com/bazelbuild/bazel/blob/49e43bbd4a3a3aa5f0f00158dff15914b69b6e85/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl#L53
 
-def _lookup_var(sctx, extra_ctx_members, additional_vars, var):
-    expanded_make_var_ctx = extra_ctx_members.var.get(var)
+def _lookup_var(ctx, additional_vars, var):
+    expanded_make_var_ctx = ctx.var.get(var)
     expanded_make_var_additional = additional_vars.get(var)
     if expanded_make_var_additional != None:
         return expanded_make_var_additional
     if expanded_make_var_ctx != None:
         return expanded_make_var_ctx
-    fail("{}: {} not defined".format(sctx.label, "$(" + var + ")"))
+    fail("{}: {} not defined".format(ctx.label, "$(" + var + ")"))
 
-def _expand_nested_variable(sctx, extra_ctx_members, additional_vars, exp, execpath = True, targets = []):
+def _expand_nested_variable(ctx, additional_vars, exp, execpath = True, targets = []):
     # If make variable is predefined path variable(like $(location ...))
     # we will expand it first.
     if exp.find(" ") != -1:
@@ -67,8 +67,8 @@ def _expand_nested_variable(sctx, extra_ctx_members, additional_vars, exp, execp
             if exp.startswith("location"):
                 exp = exp.replace("location", "rootpath", 1)
         data_targets = []
-        if extra_ctx_members.data_attr != None:
-            data_targets = extra_ctx_members.data_attr
+        if ctx.attr.data != None:
+            data_targets = ctx.attr.data
 
         # Make sure we do not duplicate targets.
         unified_targets_set = {}
@@ -76,7 +76,7 @@ def _expand_nested_variable(sctx, extra_ctx_members, additional_vars, exp, execp
             unified_targets_set[data_target] = True
         for target in targets:
             unified_targets_set[target] = True
-        return extra_ctx_members.expand_location("$({})".format(exp), targets = unified_targets_set.keys())
+        return ctx.expand_location("$({})".format(exp), targets = unified_targets_set.keys())
 
     # Recursively expand nested make variables, but since there is no recursion
     # in Starlark we will do it via for loop.
@@ -87,7 +87,7 @@ def _expand_nested_variable(sctx, extra_ctx_members, additional_vars, exp, execp
     # 10 seems to be a reasonable number, since it is highly unexpected
     # to have nested make variables which are expanding more than 10 times.
     for _ in range(10):
-        exp = _lookup_var(sctx, extra_ctx_members, additional_vars, exp)
+        exp = _lookup_var(ctx, additional_vars, exp)
         if len(exp) >= 3 and exp[0] == "$" and exp[1] == "(" and exp[len(exp) - 1] == ")":
             # Try to expand once more.
             exp = exp[2:len(exp) - 1]
@@ -99,7 +99,7 @@ def _expand_nested_variable(sctx, extra_ctx_members, additional_vars, exp, execp
         fail("potentially unbounded recursion during expansion of {}".format(exp))
     return exp
 
-def _expand(sctx, extra_ctx_members, expression, targets, additional_make_variable_substitutions, execpath = True):
+def _expand(ctx, expression, targets, additional_make_variable_substitutions, execpath = True):
     idx = 0
     last_make_var_end = 0
     result = []
@@ -141,7 +141,7 @@ def _expand(sctx, extra_ctx_members, expression, targets, additional_make_variab
                 #   last_make_var_end  make_var_start make_var_end
                 result.append(expression[last_make_var_end:make_var_start - 1])
                 make_var = expression[make_var_start + 1:make_var_end]
-                exp = _expand_nested_variable(sctx, extra_ctx_members, additional_make_variable_substitutions, make_var, execpath, targets)
+                exp = _expand_nested_variable(ctx, additional_make_variable_substitutions, make_var, execpath, targets)
                 result.append(exp)
 
                 # Update indexes.
@@ -157,30 +157,30 @@ def _expand(sctx, extra_ctx_members, expression, targets, additional_make_variab
 # Tries to expand a single make variable from token.
 # If token has additional characters other than ones
 # corresponding to make variable returns None.
-def _expand_single_make_variable(sctx, extra_ctx_members, token, additional_make_variable_substitutions):
+def _expand_single_make_variable(ctx, token, additional_make_variable_substitutions):
     if len(token) < 3:
         return None
     if token[0] != "$" or token[1] != "(" or token[len(token) - 1] != ")":
         return None
     unexpanded_var = token[2:len(token) - 1]
-    expanded_var = _expand_nested_variable(sctx, extra_ctx_members, additional_make_variable_substitutions, unexpanded_var)
+    expanded_var = _expand_nested_variable(ctx, additional_make_variable_substitutions, unexpanded_var)
     return expanded_var
 
-def _expand_make_variables_for_copts(sctx, extra_ctx_members, tokenization, unexpanded_tokens, additional_make_variable_substitutions, additional_inputs = []):
+def _expand_make_variables_for_copts(ctx, tokenization, unexpanded_tokens, additional_make_variable_substitutions, additional_inputs = []):
     tokens = []
     targets = []
     for additional_compiler_input in additional_inputs:
         targets.append(additional_compiler_input)
     for token in unexpanded_tokens:
         if tokenization:
-            expanded_token = _expand(sctx, extra_ctx_members, token, targets, additional_make_variable_substitutions)
+            expanded_token = _expand(ctx, token, targets, additional_make_variable_substitutions)
             rules_cc_helper.tokenize(tokens, expanded_token)
         else:
-            exp = _expand_single_make_variable(sctx, extra_ctx_members, token, additional_make_variable_substitutions)
+            exp = _expand_single_make_variable(ctx, token, additional_make_variable_substitutions)
             if exp != None:
                 rules_cc_helper.tokenize(tokens, exp)
             else:
-                tokens.append(_expand(sctx, extra_ctx_members, token, targets, additional_make_variable_substitutions))
+                tokens.append(_expand(ctx, token, targets, additional_make_variable_substitutions))
     return tokens
 
 def _tool_path(cc_toolchain, tool):
@@ -293,13 +293,16 @@ def _extract_sources(files):
 
     return srcs
 
-def _get_compilation_defines(sctx, extra_ctx_members, defines = [], deps = [], additional_make_variable_substitutions = {}, additional_targets = []):
+def _get_compilation_defines(ctx, defines = [], deps = [], additional_make_variable_substitutions = {}, additional_targets = []):
+    results = []
+    if not defines:
+        return results
+
     targets = [dep for dep in deps]
     targets.extend(additional_targets)
 
-    results = []
     for define in defines:
-        expanded_define = _expand(sctx, extra_ctx_members, define, targets, additional_make_variable_substitutions)
+        expanded_define = _expand(ctx, define, targets, additional_make_variable_substitutions)
 
         # Author's soap box: love the design of tokenize not returning a list..
         tokens = []
@@ -314,16 +317,22 @@ def _get_compilation_defines(sctx, extra_ctx_members, defines = [], deps = [], a
 
     return results
 
-def _get_compilation_opts(sctx, extra_ctx_members, opts, feature_configuration, additional_make_variable_substitutions = {}, additional_inputs = []):
-    tokenization = not (cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "no_copts_tokenization"))
-    return _expand_make_variables_for_copts(sctx, extra_ctx_members, tokenization, opts, additional_make_variable_substitutions, additional_inputs)
+def _get_compilation_opts(ctx, opts, feature_configuration, additional_make_variable_substitutions = {}, additional_inputs = []):
+    if not opts:
+        return []
 
-def _get_linking_opts(sctx, extra_ctx_members, opts, additional_make_variable_substitutions = {}, additional_inputs = []):
+    tokenization = not (cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "no_copts_tokenization"))
+    return _expand_make_variables_for_copts(ctx, tokenization, opts, additional_make_variable_substitutions, additional_inputs)
+
+def _get_linking_opts(ctx, opts, additional_make_variable_substitutions = {}, additional_inputs = []):
+    if not opts:
+        return []
+
     # TODO: Is this expansion sufficienct?
     results = []
     for opt in opts:
         results.append(
-            _expand(sctx, extra_ctx_members, opt, additional_inputs, additional_make_variable_substitutions),
+            _expand(ctx, opt, additional_inputs, additional_make_variable_substitutions),
         )
 
     return results
@@ -405,7 +414,47 @@ def _prepare_for_compilation(
         deps = deps,
     )
 
+def _expand_make_variables_in_defines(ctx, cc_info, action_kwargs, defines, local = False):
+    amvs = _get_toolchain_global_make_variables(cc_info.cc_toolchain)
+    amvs.update(_get_cc_flags_make_variable(cc_info.cc_toolchain, cc_info.cc_feature_configuration))
+
+    defines = _get_compilation_defines(
+        ctx,
+        defines,
+        action_kwargs.get("deps", []),
+        amvs,
+        action_kwargs.get("additional_inputs", []) if local else [],
+    ) + _get_local_defines_for_runfiles_lookup(ctx, action_kwargs.get("deps", [])) if local else []
+
+    return defines
+
+def _expand_make_variables_in_copts(ctx, cc_info, action_kwargs, opts):
+    amvs = _get_toolchain_global_make_variables(cc_info.cc_toolchain)
+    amvs.update(_get_cc_flags_make_variable(cc_info.cc_toolchain, cc_info.cc_feature_configuration))
+
+    return _get_compilation_opts(
+        ctx,
+        opts,
+        cc_info.cc_feature_configuration,
+        amvs,
+        action_kwargs.get("additional_inputs", []),
+    )
+
+def _expand_make_variables_in_linkopts(ctx, cc_info, action_kwargs, opts):
+    amvs = _get_toolchain_global_make_variables(cc_info.cc_toolchain)
+    amvs.update(_get_cc_flags_make_variable(cc_info.cc_toolchain, cc_info.cc_feature_configuration))
+
+    return _get_linking_opts(
+        ctx,
+        opts,
+        amvs,
+        action_kwargs.get("additional_inputs", []),
+    )
+
 cc_helper = struct(
+    expand_make_variables_in_copts = _expand_make_variables_in_copts,
+    expand_make_variables_in_defines = _expand_make_variables_in_defines,
+    expand_make_variables_in_linkopts = _expand_make_variables_in_linkopts,
     extract_headers = _extract_headers,
     extract_sources = _extract_sources,
     get_compilation_defines = _get_compilation_defines,

--- a/cc_hdrs_map/actions/link_to_archive.bzl
+++ b/cc_hdrs_map/actions/link_to_archive.bzl
@@ -11,8 +11,7 @@ load("@rules_cc_hdrs_map//cc_hdrs_map/actions:cc_helper.bzl", "cc_helper")
 def _link_to_archive_impl(
         sctx,
         compilation_outputs,
-        extra_ctx_members = None,
-        configure_features_func = [],
+        cc_feature_configuration_func = [],
         features = [],
         disabled_features = [],
         deps = [],
@@ -26,7 +25,7 @@ def _link_to_archive_impl(
 
     Args:
         sctx: subrule context
-        configure_features_func: function that will provide [FeatureConfiguration](https://bazel.build/rules/lib/builtins/FeatureConfiguration.html)
+        cc_feature_configuration_func: function that will provide [FeatureConfiguration](https://bazel.build/rules/lib/builtins/FeatureConfiguration.html)
         features: list of features specified for the linking
         disabled_features = list of disabled features specified for the linking
         deps: list of dependencies provided for the linking
@@ -35,8 +34,8 @@ def _link_to_archive_impl(
         additional_inputs: for additional inputs to the linking action, e.g.: linking scripts
         variables_extension: additional variables to pass to the toolchain configuration when creating link command line
     """
-    if not configure_features_func:
-        fail("link_to_archive subrule requires for the 'configure_features_func' kwarg to be set!")
+    if not cc_feature_configuration_func:
+        fail("link_to_archive subrule requires for the 'cc_feature_configuration_func' kwarg to be set!")
 
     cc_toolchain = find_cc_toolchain(sctx)
 
@@ -48,7 +47,7 @@ def _link_to_archive_impl(
     linking_context, linking_outputs = cc_common.create_linking_context_from_compilation_outputs(
         actions = sctx.actions,
         name = archive_lib_name,
-        feature_configuration = configure_features_func(
+        feature_configuration = cc_feature_configuration_func(
             cc_toolchain,
             features = features,
             disabled_features = disabled_features,
@@ -62,7 +61,7 @@ def _link_to_archive_impl(
             for dep in deps
             if CcInfo in dep
         ],
-        user_link_flags = cc_helper.get_linking_opts(sctx, extra_ctx_members, user_link_flags, additional_inputs),
+        user_link_flags = user_link_flags,
         alwayslink = False,
         # TODO: Is there a better way?
         additional_inputs = depset([], transitive = [i.files for i in additional_inputs]).to_list(),

--- a/cc_hdrs_map/actions/link_to_binary.bzl
+++ b/cc_hdrs_map/actions/link_to_binary.bzl
@@ -10,8 +10,7 @@ load("@rules_cc_hdrs_map//cc_hdrs_map/actions:cc_helper.bzl", "cc_helper")
 def _link_to_binary_impl(
         sctx,
         compilation_outputs,
-        extra_ctx_members = None,
-        configure_features_func = [],
+        cc_feature_configuration_func = [],
         features = [],
         disabled_features = [],
         deps = [],
@@ -32,7 +31,7 @@ def _link_to_binary_impl(
 
     Args:
         sctx: subrule context
-        configure_features_func: function that will provide [FeatureConfiguration](https://bazel.build/rules/lib/builtins/FeatureConfiguration.html)
+        cc_feature_configuration_func: function that will provide [FeatureConfiguration](https://bazel.build/rules/lib/builtins/FeatureConfiguration.html)
         features: list of features specified for the linking
         disabled_features = list of disabled features specified for the linking
         deps: list of dependencies provided for the linking
@@ -46,8 +45,8 @@ def _link_to_binary_impl(
         additional_inputs: for additional inputs to the linking action, e.g.: linking scripts
         variables_extension: additional variables to pass to the toolchain configuration when create link command line
     """
-    if not configure_features_func:
-        fail("link_to_binary subrule requires for the 'configure_features_func' kwarg to be set!")
+    if not cc_feature_configuration_func:
+        fail("link_to_binary subrule requires for the 'cc_feature_configuration_func' kwarg to be set!")
 
     cc_toolchain = find_cc_toolchain(sctx)
 
@@ -82,7 +81,7 @@ def _link_to_binary_impl(
     return cc_common.link(
         actions = sctx.actions,
         name = sctx.label.name,
-        feature_configuration = configure_features_func(
+        feature_configuration = cc_feature_configuration_func(
             cc_toolchain,
             features = features,
             disabled_features = disabled_features,
@@ -92,7 +91,7 @@ def _link_to_binary_impl(
         link_deps_statically = True,
         compilation_outputs = compilation_outputs,
         linking_contexts = linking_contexts,
-        user_link_flags = cc_helper.get_linking_opts(sctx, extra_ctx_members, user_link_flags, additional_inputs),
+        user_link_flags = user_link_flags,
         stamp = stamp,
         # Adding transitive sols makes the compilation
         # work with --unresolved-symbols='report-all'

--- a/cc_hdrs_map/actions/link_to_so.bzl
+++ b/cc_hdrs_map/actions/link_to_so.bzl
@@ -13,8 +13,7 @@ load("@rules_cc_hdrs_map//cc_hdrs_map/providers:cc_shared_library_info.bzl", "me
 def _link_to_so_impl(
         sctx,
         compilation_outputs,
-        extra_ctx_members = None,
-        configure_features_func = [],
+        cc_feature_configuration_func = [],
         features = [],
         disabled_features = [],
         deps = [],
@@ -29,7 +28,7 @@ def _link_to_so_impl(
 
     Args:
         sctx: subrule context
-        configure_features_func: function that will provide [FeatureConfiguration](https://bazel.build/rules/lib/builtins/FeatureConfiguration.html)
+        cc_configuration_func: function that will provide [FeatureConfiguration](https://bazel.build/rules/lib/builtins/FeatureConfiguration.html)
         features: list of features specified for the linking
         disabled_features: list of disabled features specified for the linking
         deps: list of dependencies provided for the linking
@@ -38,8 +37,8 @@ def _link_to_so_impl(
         additional_inputs: for additional inputs to the linking action, e.g.: linking scripts
         variables_extension: additional variables to pass to the toolchain configuration when creating link command line
     """
-    if not configure_features_func:
-        fail("link_to_so subrule requires for the 'configure_features_func' kwarg to be set!")
+    if not cc_feature_configuration_func:
+        fail("link_to_so subrule requires for the 'cc_feature_configuration_func' kwarg to be set!")
 
     cc_toolchain = find_cc_toolchain(sctx)
 
@@ -70,7 +69,7 @@ def _link_to_so_impl(
     linking_outputs = cc_common.link(
         actions = sctx.actions,
         name = sol_name,
-        feature_configuration = configure_features_func(
+        feature_configuration = cc_feature_configuration_func(
             cc_toolchain,
             features = features + ["force_no_whole_archive"],
             disabled_features = disabled_features,
@@ -82,7 +81,7 @@ def _link_to_so_impl(
         linking_contexts = [cc_common.create_linking_context(
             linker_inputs = depset(direct = linking_inputs, order = "topological"),
         )] + linking_contexts,
-        user_link_flags = cc_helper.get_linking_opts(sctx, extra_ctx_members, user_link_flags, additional_inputs),
+        user_link_flags = user_link_flags,
         stamp = 0,
         # I am leaving this in because I am petty
         # Error in check_private_api: file '@@rules_cc_hdrs_map+//cc_hdrs_map/actions:link_to_so.bzl' cannot use private API

--- a/cc_hdrs_map/private/attrs.bzl
+++ b/cc_hdrs_map/private/attrs.bzl
@@ -1,6 +1,6 @@
 """ Contains common configuration-related entities used by cc_hdrs_map rules. """
 
-load("@rules_cc_hdrs_map//cc_hdrs_map/actions:cc_helper.bzl", "CC_HEADER_EXTENSIONS", "CC_SOURCE_EXTENSIONS")
+load("@rules_cc_hdrs_map//cc_hdrs_map/actions:cc_helper.bzl", "CC_HEADER_EXTENSIONS", "CC_SOURCE_EXTENSIONS", "cc_helper")
 load("@rules_cc_hdrs_map//cc_hdrs_map/providers:hdrs_map.bzl", "new_hdrs_map")
 
 def _not_yet_implemented(ctx_attr, attr_name):
@@ -197,6 +197,7 @@ _CC_COMPILABLE_ATTRS = {
             link_to_bin = lambda ctx_attr: None,
             link_to_so = lambda ctx_attr: None,
         ),
+        expand_make_variables = lambda ctx, cc_info, action_kwargs: ("conly_flags", cc_helper.expand_make_variables_in_copts(ctx, cc_info, action_kwargs, action_kwargs.get("conly_flags"))),
     ),
     "copts": struct(
         attr = attr.string_list(
@@ -214,6 +215,7 @@ _CC_COMPILABLE_ATTRS = {
             link_to_bin = lambda ctx_attr: None,
             link_to_so = lambda ctx_attr: None,
         ),
+        expand_make_variables = lambda ctx, cc_info, action_kwargs: ("user_compile_flags", cc_helper.expand_make_variables_in_copts(ctx, cc_info, action_kwargs, action_kwargs.get("user_compile_flags"))),
     ),
     "cxxopts": struct(
         attr = attr.string_list(
@@ -228,6 +230,7 @@ _CC_COMPILABLE_ATTRS = {
             link_to_bin = lambda ctx_attr: None,
             link_to_so = lambda ctx_attr: None,
         ),
+        expand_make_variables = lambda ctx, cc_info, action_kwargs: ("cxx_flags", cc_helper.expand_make_variables_in_copts(ctx, cc_info, action_kwargs, action_kwargs.get("cxx_flags"))),
     ),
     "defines": struct(
         attr = attr.string_list(
@@ -242,6 +245,7 @@ _CC_COMPILABLE_ATTRS = {
             link_to_bin = lambda ctx_attr: None,
             link_to_so = lambda ctx_attr: None,
         ),
+        expand_make_variables = lambda ctx, cc_info, action_kwargs: ("defines", cc_helper.expand_make_variables_in_defines(ctx, cc_info, action_kwargs, action_kwargs.get("defines"))),
     ),
     "dynamic_deps": struct(
         attr = attr.label_list(
@@ -318,6 +322,7 @@ _CC_COMPILABLE_ATTRS = {
             link_to_bin = lambda ctx_attr: ("user_link_flags", getattr(ctx_attr, "linkopts", [])),
             link_to_so = lambda ctx_attr: ("user_link_flags", getattr(ctx_attr, "linkopts", [])),
         ),
+        expand_make_variables = lambda ctx, cc_info, action_kwargs: ("user_link_flags", cc_helper.expand_make_variables_in_linkopts(ctx, cc_info, action_kwargs, action_kwargs.get("user_link_flags"))),
     ),
     "linkshared": struct(
         attr = attr.bool(
@@ -375,6 +380,7 @@ _CC_COMPILABLE_ATTRS = {
             link_to_bin = lambda ctx_attr: None,
             link_to_so = lambda ctx_attr: None,
         ),
+        expand_make_variables = lambda ctx, cc_info, action_kwargs: ("local_defines", cc_helper.expand_make_variables_in_defines(ctx, cc_info, action_kwargs, action_kwargs.get("local_defines"), local = True)),
     ),
     "malloc": struct(
         attr = attr.label(


### PR DESCRIPTION
This change resolves design issue with how the logic of the ruleset was structured (assuming a subrule could call ctx.expand_location).

All make variable expansions for copts, defines and linkopts should be functional now.