### PR TITLE
fix(attrs): remove deduplication from list attrs

### DIFF
--- a/cc_hdrs_map/actions/defs.bzl
+++ b/cc_hdrs_map/actions/defs.bzl
@@ -54,8 +54,6 @@ def _attrs_into_action_kwargs(ctx, rule_attrs, action_name):
         if type(kwarg_meta[1]) == "list":
             compile_kwarg = action_kwargs.setdefault(kwarg_meta[0], [])
             for kwarg in kwarg_meta[1]:
-                if kwarg in compile_kwarg:
-                    continue
                 compile_kwarg.append(kwarg)
 
             # TODO: Handling of a dictionaries merge


### PR DESCRIPTION
This changeset relaxes the handling of rule attrs
that are lists, where any duplicates were aggresively removed - this is no longer the case.

The rationale is - it is not infrequent for certain attrs (like linkopts) to expect to  have elements
in list repeated and it is not a mistake.